### PR TITLE
chore(cms): rename npm package backend-blog -> cms

### DIFF
--- a/cms/package-lock.json
+++ b/cms/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "backend-blog",
+  "name": "cms",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "backend-blog",
+      "name": "cms",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/cms/package.json
+++ b/cms/package.json
@@ -14,7 +14,7 @@
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },
-  "name": "backend-blog",
+  "name": "cms",
   "private": true,
   "version": "0.1.0",
   "description": "A Strapi application",


### PR DESCRIPTION
Renames the Strapi app's npm package name to match its `cms/` folder (package.json + lockfile). Verified `npm ci` / Strapi image build still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)